### PR TITLE
Improve documentation for locale import.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ To be used with amDateFormat pipe in order to change locale.
 
 Prints `Last updated: January 24th 2016, 2:23:45 pm`
 
+Note: The locale might have to be imported (e.g. in the app module).
+
+``` typescript
+import 'moment/locale/de';
+```
+
 ## amFromUnix pipe
 
 ``` typescript


### PR DESCRIPTION
When I used the amLocale pipe, I was struggeling with getting the locale loaded. When I did something like

```
{{ myMoment | amLocale:'de' | amDateFormat:'MMMM' }}
```

to show the month of a date, I always got the english name of the month. After searching the issues, I found https://github.com/urish/ngx-moment/issues/149#issuecomment-315011495, what finally helped me. I checked my node_modules that moment was installed and just did the import. I didn't test in my project, if the manual installation of moment.js is necesssary on a clean project.

I think, it would improve the documentation, if this note is added.