### PR TITLE
Add `amParseZone` pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,21 @@ Enables UTC mode for subsequent moment operations (such as displaying the time i
 
 Prints `Last updated: 2017-01-01`
 
+## amParseZone pipe
+
+Parses a string but keeps the resulting Moment object in a fixed-offset timezone with the provided offset in the string.
+
+``` typescript
+@Component({
+  selector: 'app',
+  template: `
+    Last updated: {{ '2016-12-31T23:00:00.000-03:00' | amParseZone | amDateFormat: 'LLLL (Z)' }}
+  `
+})
+```
+
+Prints `Last updated: Saturday, December 31, 2016 11:00 PM (-03:00)`
+
 Complete Example
 ----------------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export { UtcPipe } from './utc.pipe';
 export { FromUtcPipe } from './from-utc.pipe';
 export { LocalTimePipe } from './local.pipe';
 export { LocalePipe } from './locale.pipe';
+export { ParseZonePipe } from './parse-zone.pipe';

--- a/src/moment.module.ts
+++ b/src/moment.module.ts
@@ -13,6 +13,7 @@ import { UtcPipe } from './utc.pipe';
 import { FromUtcPipe } from './from-utc.pipe';
 import { LocalTimePipe } from './local.pipe';
 import { LocalePipe } from './locale.pipe';
+import { ParseZonePipe } from './parse-zone.pipe';
 
 const ANGULAR_MOMENT_PIPES = [
   AddPipe,
@@ -27,7 +28,8 @@ const ANGULAR_MOMENT_PIPES = [
   UtcPipe,
   FromUtcPipe,
   LocalTimePipe,
-  LocalePipe
+  LocalePipe,
+  ParseZonePipe
 ];
 
 @NgModule({

--- a/src/parse-zone.pipe.spec.ts
+++ b/src/parse-zone.pipe.spec.ts
@@ -1,0 +1,43 @@
+import * as moment from 'moment';
+import { ParseZonePipe } from './parse-zone.pipe';
+
+describe('ParseZonePipe', () => {
+
+  describe('#transform', () => {
+
+    let parseZonePipe: ParseZonePipe;
+
+    beforeEach(() => {
+      parseZonePipe = new ParseZonePipe();
+    });
+
+    it('should output an invalid momemt object for a null input', () => {
+      const parsedDate = parseZonePipe.transform(null);
+      expect(parsedDate).toEqual(expect.any(moment));
+      expect(parsedDate.isValid()).toBe(false);
+    });
+
+    it('should parse a date in ISO_8601 format', () => {
+      const date: string = moment().toISOString();
+      const parsedDate = parseZonePipe.transform(date);
+      expect(parsedDate).toEqual(expect.any(moment));
+      expect(parsedDate.isValid()).toBe(true);
+    });
+
+    it('should preserve a positive UTC offset', () => {
+      const offset = 720;
+      const date = moment().utcOffset(offset).format();
+      const parsedDate = parseZonePipe.transform(date);
+      expect(parsedDate.utcOffset()).toEqual(offset);
+    });
+
+    it('should preserve a negative UTC offset', () => {
+      const offset = -720;
+      const date = moment().utcOffset(offset).format();
+      const parsedDate = parseZonePipe.transform(date);
+      expect(parsedDate.utcOffset()).toEqual(offset);
+    });
+
+  });
+
+});

--- a/src/parse-zone.pipe.ts
+++ b/src/parse-zone.pipe.ts
@@ -1,0 +1,9 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import * as moment from 'moment';
+
+@Pipe({ name: 'amParseZone' })
+export class ParseZonePipe implements PipeTransform {
+  transform(value: string): moment.Moment {
+    return moment.parseZone(value);
+  }
+}


### PR DESCRIPTION
Hello!

With this pipe you can parse a string into a moment object preserving the original UTC offset. Its addition was suggested in [issue#39](https://github.com/urish/ngx-moment/issues/39) and can be handy.