### PR TITLE
Allow using all supported Moment inputs with TimeAgoPipe

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -18,14 +18,6 @@
             }
           }
         },
-        "test": {
-          "builder": "@angular-devkit/build-angular:karma",
-          "options": {
-            "main": "src/test.ts",
-            "tsConfig": "tsconfig.spec.json",
-            "karmaConfig": "karma.conf.js"
-          }
-        },
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Moment.JS pipes for Angular (timeago and more)",
   "scripts": {
     "build": "ng build",
-    "test": "ng lint && jest",
+    "test": "ng lint && tsc -p tsconfig.spec.json && jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk --inspect ./node_modules/jest/bin/jest.js --runInBand",

--- a/src/time-ago.pipe.spec.ts
+++ b/src/time-ago.pipe.spec.ts
@@ -37,6 +37,12 @@ describe('TimeAgoPipe', () => {
       expect(pipe.transform(new Date())).toBe('a few seconds ago');
     });
 
+    it('should support string dates', () => {
+      const pipe = new TimeAgoPipe(null, new NgZoneMock() as NgZone);
+      const dateStr = new Date().toISOString();
+      expect(pipe.transform(dateStr)).toBe('a few seconds ago');
+    });
+
     it('should omit the suffix if second parameter is truthy', () => {
       const pipe = new TimeAgoPipe(null, new NgZoneMock() as NgZone);
       expect(pipe.transform(new Date(new Date().getTime() + 60000), true)).toBe('a minute');

--- a/src/time-ago.pipe.ts
+++ b/src/time-ago.pipe.ts
@@ -10,7 +10,7 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
   private currentTimer: number | null;
 
   private lastTime: Number;
-  private lastValue: Date | moment.Moment;
+  private lastValue: moment.MomentInput;
   private lastOmitSuffix: boolean;
   private lastLocale?: string;
   private lastText: string;
@@ -18,7 +18,7 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
   constructor(private cdRef: ChangeDetectorRef, private ngZone: NgZone) {
   }
 
-  transform(value: Date | moment.Moment, omitSuffix?: boolean): string {
+  transform(value: moment.MomentInput, omitSuffix?: boolean): string {
     if (this.hasChanged(value, omitSuffix)) {
       this.lastTime = this.getTime(value);
       this.lastValue = value;
@@ -39,14 +39,14 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
     this.removeTimer();
   }
 
-
   private createTimer() {
     if (this.currentTimer) {
       return;
     }
-    const momentInstance = momentConstructor(this.lastValue);
 
+    const momentInstance = momentConstructor(this.lastValue);
     const timeToUpdate = this.getSecondsUntilUpdate(momentInstance) * 1000;
+
     this.currentTimer = this.ngZone.runOutsideAngular(() => {
       if (typeof window !== 'undefined') {
         return window.setTimeout(() => {
@@ -60,7 +60,6 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
       }
     });
   }
-
 
   private removeTimer() {
     if (this.currentTimer) {
@@ -82,13 +81,13 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
     }
   }
 
-  private hasChanged(value: Date | moment.Moment, omitSuffix?: boolean) {
+  private hasChanged(value: moment.MomentInput, omitSuffix?: boolean): boolean {
     return this.getTime(value) !== this.lastTime
       || this.getLocale(value) !== this.lastLocale
       || omitSuffix !== this.lastOmitSuffix;
   }
 
-  private getTime(value: Date | moment.Moment) {
+  private getTime(value: moment.MomentInput): number {
     if (moment.isDate(value)) {
       return value.getTime();
     } else if (moment.isMoment(value)) {
@@ -98,7 +97,7 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
     }
   }
 
-  private getLocale(value: Date | moment.Moment): string {
+  private getLocale(value: moment.MomentInput): string | null {
     return moment.isMoment(value) ? value.locale() : null;
   }
 }

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -6,7 +6,6 @@
     "types": []
   },
   "exclude": [
-    "src/test.ts",
-    "**/*.spec.ts"
+    "src/*.spec.ts"
   ]
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,17 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./out-tsc/spec",
+    "noEmit": true,
     "types": [
-      "jasmine",
+      "jest",
       "node"
     ]
   },
-  "files": [
-    "src/test.ts"
-  ],
   "include": [
-    "**/*.spec.ts",
-    "**/*.d.ts"
+    "src/*.spec.ts"
   ]
 }


### PR DESCRIPTION
Makes it possible to use `TimeAgoPipe` with string/number dates when the `fullTemplateTypeCheck` Angular compiler option is enabled. Fixes #204.

Also enables type checking when running tests. Previously a test could contain a type error, but all tests would be reported as passing since ts-jest only uses TypeScript as a file preprocessor (see kulshekhar/ts-jest#79).

This is a non-breaking change which can be included in a minor/patch release.