### PR TITLE
issue #202 ability to provide options to the MomentModule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .ng_pkg_build
 *.log
 dist
+/package-lock.json

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ import { MomentModule } from 'ngx-moment';
 })
 ```
 
+If you would like to supply any `NgxMomentOptions` that will be made available to the pipes you can also use:
+
+```typescript
+import { MomentModule } from 'ngx-moment';
+
+@NgModule({
+  imports: [
+    MomentModule.forRoot({
+      relativeTimeThresholdOptions: {
+        'm': 59
+      }
+    })
+  ]
+})
+```
+
 This makes all the `ngx-moment` pipes available for use in your app components.
 
 Available pipes
@@ -331,6 +347,13 @@ Prints `Today is before tomorrow: true`
 
 Prints `Tomorrow is after today: true`
 
+NgxMomentOptions
+----------------
+An `NgxMomentOptions` object can be provided to the module using the `forRoot` convention and will provide options for the pipes to use with the `moment` instance, these options are detailed in the table below:
+
+| prop | type | description |
+| --- |:---:| --- |
+| relativeTimeThresholdOptions | Dictionary<br>key: string<br>value: number | Provides the `relativeTimeThreshold` units allowing a pipe to set the `moment.relativeTimeThreshold` values. <br><br>The `key` is a unit defined as one of `ss`, `s`, `m`, `h`, `d`, `M`.<br><br>See [Relative Time Thresholds](https://momentjs.com/docs/#/customization/relative-time-threshold/) documentation for more details. |
 
 Complete Example
 ----------------

--- a/src/duration.pipe.spec.ts
+++ b/src/duration.pipe.spec.ts
@@ -1,4 +1,5 @@
-import {DurationPipe} from './duration.pipe';
+import { DurationPipe } from './duration.pipe';
+import { NgxMomentOptions } from './moment-options';
 
 describe('DurationPipe', () => {
   let pipe: DurationPipe;
@@ -16,6 +17,24 @@ describe('DurationPipe', () => {
       expect(pipe.transform(365, 'seconds')).toEqual('6 minutes');
       expect(pipe.transform(365, 'days')).toEqual('a year');
       expect(pipe.transform(86400, 'seconds')).toEqual('a day');
+    });
+
+    it(`should convert '50 minutes' to 'an hour' with default 'relativeTimeThreshold'`, () => {
+      expect(pipe.transform(50, 'minutes')).toEqual('an hour');
+    });
+  });
+
+  describe('ctor with NgxMomentOptions', () => {
+    const momentOptions: NgxMomentOptions = {
+      relativeTimeThresholdOptions: {
+        'm': 59
+      }
+    };
+
+    beforeEach(() => pipe = new DurationPipe(momentOptions));
+
+    it(`should convert '50 minutes' to '50 minutes' when relativeTimeThreshold for 'm' unit is set to 59`, () => {
+      expect(pipe.transform(50, 'minutes')).toEqual('50 minutes');
     });
   });
 });

--- a/src/duration.pipe.ts
+++ b/src/duration.pipe.ts
@@ -1,12 +1,36 @@
-import {Pipe, PipeTransform} from '@angular/core';
 import * as moment from 'moment';
+
+import { Inject, Optional, Pipe, PipeTransform } from '@angular/core';
+import { NGX_MOMENT_OPTIONS, NgxMomentOptions } from './moment-options';
 
 @Pipe({ name: 'amDuration' })
 export class DurationPipe implements PipeTransform {
+
+  allowedUnits: Array<string> = ['ss', 's', 'm', 'h', 'd', 'M'];
+
+  constructor(@Optional() @Inject(NGX_MOMENT_OPTIONS) momentOptions?: NgxMomentOptions) {
+    this._applyOptions(momentOptions);
+  }
+
   transform(value: any, ...args: string[]): string {
     if (typeof args === 'undefined' || args.length !== 1) {
       throw new Error('DurationPipe: missing required time unit argument');
     }
     return moment.duration(value, args[0] as moment.unitOfTime.DurationConstructor).humanize();
   }
+
+  private _applyOptions(momentOptions: NgxMomentOptions): void {
+    if (!!!momentOptions) {
+      return;
+    }
+
+    if (!!momentOptions.relativeTimeThresholdOptions) {
+      const units: Array<string> = Object.keys(momentOptions.relativeTimeThresholdOptions);
+      const filteredUnits: Array<string> = units.filter(unit => this.allowedUnits.indexOf(unit) !== -1);
+      filteredUnits.forEach(unit => {
+        moment.relativeTimeThreshold(unit, momentOptions.relativeTimeThresholdOptions[unit]);
+      });
+    }
+  }
+
 }

--- a/src/duration.pipe.ts
+++ b/src/duration.pipe.ts
@@ -20,7 +20,7 @@ export class DurationPipe implements PipeTransform {
   }
 
   private _applyOptions(momentOptions: NgxMomentOptions): void {
-    if (!!!momentOptions) {
+    if (!momentOptions) {
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,4 @@ export { ParseZonePipe } from './parse-zone.pipe';
 export { IsBeforePipe } from './is-before.pipe';
 export { IsAfterPipe } from './is-after.pipe';
 
-export { NgxMomentOptions } from './moment-options';
+export { NgxMomentOptions, NGX_MOMENT_OPTIONS } from './moment-options';

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,5 @@ export { LocalePipe } from './locale.pipe';
 export { ParseZonePipe } from './parse-zone.pipe';
 export { IsBeforePipe } from './is-before.pipe';
 export { IsAfterPipe } from './is-after.pipe';
+
+export { NgxMomentOptions } from './moment-options';

--- a/src/moment-options.ts
+++ b/src/moment-options.ts
@@ -1,0 +1,17 @@
+import { InjectionToken } from '@angular/core';
+
+export const NGX_MOMENT_OPTIONS: InjectionToken<string> = new InjectionToken<string>('NGX_MOMENT_OPTIONS');
+
+export interface NgxMomentOptions {
+  /**
+   * relativeTimeThresholdOptions
+   * @description Provides the `relativeTimeThreshold` units allowing a pipe to set the `moment.relativeTimeThreshold` values.
+   * The `key` is a unit defined as one of `ss`, `s`, `m`, `h`, `d`, `M`.
+   * @type {{relativeTimeThresholdOptions: Object.<string, number>}}
+   * @see https://momentjs.com/docs/#/customization/relative-time-threshold/
+   * @example by default more than 45 seconds is considered a minute, more than 22 hours is considered a day and so on.
+   * So settings the unit 'm' to `59` will adjust the `relativeTimeThreshold` and consider more than 59 minutes
+   * to be an hour (default is `45 minutes`)
+   */
+  relativeTimeThresholdOptions: { [key: string]: number };
+}

--- a/src/moment-options.ts
+++ b/src/moment-options.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@angular/core';
 
-export const NGX_MOMENT_OPTIONS: InjectionToken<string> = new InjectionToken<string>('NGX_MOMENT_OPTIONS');
+export const NGX_MOMENT_OPTIONS: InjectionToken<NgxMomentOptions> = new InjectionToken<NgxMomentOptions>('NGX_MOMENT_OPTIONS');
 
 export interface NgxMomentOptions {
   /**

--- a/src/moment-options.ts
+++ b/src/moment-options.ts
@@ -7,7 +7,6 @@ export interface NgxMomentOptions {
    * relativeTimeThresholdOptions
    * @description Provides the `relativeTimeThreshold` units allowing a pipe to set the `moment.relativeTimeThreshold` values.
    * The `key` is a unit defined as one of `ss`, `s`, `m`, `h`, `d`, `M`.
-   * @type {{relativeTimeThresholdOptions: Object.<string, number>}}
    * @see https://momentjs.com/docs/#/customization/relative-time-threshold/
    * @example by default more than 45 seconds is considered a minute, more than 22 hours is considered a day and so on.
    * So settings the unit 'm' to `59` will adjust the `relativeTimeThreshold` and consider more than 59 minutes

--- a/src/moment.module.ts
+++ b/src/moment.module.ts
@@ -1,3 +1,6 @@
+import { ModuleWithProviders, NgModule } from '@angular/core';
+import { NGX_MOMENT_OPTIONS, NgxMomentOptions } from './moment-options';
+
 import { AddPipe } from './add.pipe';
 import { CalendarPipe } from './calendar.pipe';
 import { DateFormatPipe } from './date-format.pipe';
@@ -9,7 +12,6 @@ import { IsAfterPipe } from './is-after.pipe';
 import { IsBeforePipe } from './is-before.pipe';
 import { LocalTimePipe } from './local.pipe';
 import { LocalePipe } from './locale.pipe';
-import { NgModule } from '@angular/core';
 import { ParsePipe } from './parse.pipe';
 import { ParseZonePipe } from './parse-zone.pipe';
 import { SubtractPipe } from './subtract.pipe';
@@ -39,4 +41,17 @@ const ANGULAR_MOMENT_PIPES = [
   declarations: ANGULAR_MOMENT_PIPES,
   exports: ANGULAR_MOMENT_PIPES
 })
-export class MomentModule { }
+export class MomentModule {
+  static forRoot(options?: NgxMomentOptions): ModuleWithProviders {
+    return {
+      ngModule: MomentModule,
+      providers: [
+        {
+          provide: NGX_MOMENT_OPTIONS, useValue: {
+            ...options
+          }
+        }
+      ]
+    };
+  }
+}


### PR DESCRIPTION
Add ability to provide options to the moment module using the `forRoot` convention to supply options globally or per pipe