### PR TITLE
TimeAgoPipe: Improved Text Update on locale change when not using MomentInput

### DIFF
--- a/src/time-ago.pipe.spec.ts
+++ b/src/time-ago.pipe.spec.ts
@@ -26,7 +26,7 @@ describe('TimeAgoPipe', () => {
 
     beforeEach(() => {
       moment.locale('en-gb');
-      jest.useFakeTimers()
+      jest.useFakeTimers();
     });
 
     afterEach(() => {

--- a/src/time-ago.pipe.spec.ts
+++ b/src/time-ago.pipe.spec.ts
@@ -24,7 +24,10 @@ function fakeDate(defaultDate: string | number) {
 describe('TimeAgoPipe', () => {
   describe('#transform', () => {
 
-    beforeEach(() => jest.useFakeTimers());
+    beforeEach(() => {
+      moment.locale('en-gb');
+      jest.useFakeTimers()
+    });
 
     afterEach(() => {
       global.Date = _Date;
@@ -81,6 +84,15 @@ describe('TimeAgoPipe', () => {
       fakeDate('2016-05-01');
       expect(pipe.transform(moment(0).locale('pl'))).toBe('46 lat temu');
       expect(pipe.transform(new Date(0))).toBe('46 years ago');
+    });
+
+    it('should update the text when using Date Objects and locale changes', () => {
+      const changeDetectorMock = { markForCheck: jest.fn() };
+      const pipe = new TimeAgoPipe(changeDetectorMock as any, new NgZoneMock() as NgZone);
+      fakeDate('2016-05-01');
+      expect(pipe.transform(new Date(0))).toBe('46 years ago');
+      moment.locale('de');
+      expect(pipe.transform(new Date(0))).toBe('vor 46 Jahren');
     });
 
     it('should update the text when the date instance time is updated', () => {

--- a/src/time-ago.pipe.ts
+++ b/src/time-ago.pipe.ts
@@ -98,6 +98,6 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
   }
 
   private getLocale(value: moment.MomentInput): string | null {
-    return moment.isMoment(value) ? value.locale() : null;
+    return moment.isMoment(value) ? value.locale() : moment.locale();
   }
 }


### PR DESCRIPTION
With this PR, the text of the amTimeAgo Pipe is updated when using plain Date-Values and changing the global locale (via e.g. "moment.locale('de')")

