### PR TITLE
feat: add format|formats to from-utc pipe and parse-pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,26 @@ Parses a custom-formatted date into a moment object that can be used with the ot
 
 Prints `Last updated: January 24, 2016`
 
+The pipe can also accept an array of formats as parameter.
+
+``` typescript
+@Component({
+  selector: 'app',
+  template: `
+    Last updated: {{'24/01/2014 22:00' | amParse: formats | amDateFormat:'LL'}}
+  `
+})
+export class App {
+
+  formats: string[] = ['DD/MM/YYYY HH:mm:ss', 'DD/MM/YYYY HH:mm'];
+
+  constructor() { }
+
+}
+```
+
+Prints `Last updated: January 24, 2016`
+
 ## amLocal pipe
 
 Converts UTC time to local time.
@@ -290,6 +310,37 @@ Parses the date as UTC and enables mode for subsequent moment operations (such a
 ```
 
 Prints `Last updated: 2017-01-01`
+
+It's also possible to specify a different format than the standard ISO8601.
+
+``` typescript
+@Component({
+  selector: 'app',
+  template: `
+    Last updated: {{ '31/12/2016 23:00-01:00' | amFromUtc: 'DD/MM/YYYY HH:mmZZ' | amDateFormat: 'YYYY-MM-DD' }}
+  `
+})
+```
+
+Or even an array of formats:
+
+``` typescript
+@Component({
+  selector: 'app',
+  template: `
+    Last updated: {{ '31/12/2016 23:00-01:00' | amFromUtc: formats | amDateFormat: 'YYYY-MM-DD' }}
+  `
+})
+export class App {
+  
+  formats: string[] = ['DD/MM/YYYY HH:mm:ss', 'DD/MM/YYYY HH:mmZZ'];
+
+  constructor() { }
+
+}
+```
+
+Both examples above will print `Last updated: 2017-01-01`
 
 ## amUtc pipe
 

--- a/src/from-utc.pipe.spec.ts
+++ b/src/from-utc.pipe.spec.ts
@@ -62,6 +62,37 @@ describe('UtcPipe', () => {
       expect(amDateFormat.transform(utcOutput, momentFormatString)).toEqual('2016-12-31');
     });
 
+    it('should parse as UTC with a provided format', () => {
+      const datetimeString = '31/12/2016, 23:02:00';
+      const momentFormatString = 'DD/MM/YYYY, HH:mm:ss';
+      const utcOutput = utcDatePipe.transform(datetimeString, momentFormatString);
+      expect(utcOutput).toEqual(expect.any(moment));
+      expect(utcOutput.isValid()).toBe(true);
+
+      expect(utcOutput.year()).toBe(2016);
+      expect(utcOutput.month()).toBe(11);
+      expect(utcOutput.date()).toBe(31);
+    });
+
+    it('should parse as UTC with an array of provided formats', () => {
+      const datetimeString = '31st 12/2016';
+      const momentFormatStrings = ['DD/MM/YYYY, HH:mm:ss', 'Do MM/YYYY'];
+      const utcOutput = utcDatePipe.transform(datetimeString, momentFormatStrings);
+      expect(utcOutput).toEqual(expect.any(moment));
+      expect(utcOutput.isValid()).toBe(true);
+
+      expect(utcOutput.year()).toBe(2016);
+      expect(utcOutput.month()).toBe(11);
+      expect(utcOutput.date()).toBe(31);
+    });
+
+    it('should output an invalid moment object for a different formatted input', () => {
+      const datetimeString = '31/12/2016, 23:02:00';
+      const utcDate = utcDatePipe.transform(datetimeString);
+      expect(utcDate).toEqual(expect.any(moment));
+      expect(utcDate.isValid()).toBe(false);
+    });
+
   });
 
 });

--- a/src/from-utc.pipe.ts
+++ b/src/from-utc.pipe.ts
@@ -5,7 +5,7 @@ import * as moment from 'moment';
 
 @Pipe({ name: 'amFromUtc' })
 export class FromUtcPipe implements PipeTransform {
-  transform(value: any, ...args: string[]): any {
-    return moment.utc(value);
+  transform(value: any, formats?: string|string[], ...args: string[]): any {
+    return formats ? moment.utc(value, formats) : moment.utc(value);
   }
 }

--- a/src/parse.pipe.spec.ts
+++ b/src/parse.pipe.spec.ts
@@ -33,6 +33,18 @@ describe('ParsePipe', () => {
       expect(amDateFormat.transform(parseOutput, momentFormatString)).toEqual('2016-02-01');
     });
 
+    it('should output a moment object for a string date with array of formats', () => {
+      const dateString = '15--09//13';
+      const formatInputStrings = ['YYYY#MM#DD', 'YY--MM//DD'];
+      const parsedMoment = parsePipe.transform(dateString, formatInputStrings);
+      expect(parsedMoment).toEqual(expect.any(moment));
+      expect(parsedMoment.isValid()).toBe(true);
+
+      expect(parsedMoment.year()).toBe(2015);
+      expect(parsedMoment.month()).toBe(8);
+      expect(parsedMoment.date()).toBe(13);
+    });
+
   });
 
 });

--- a/src/parse.pipe.ts
+++ b/src/parse.pipe.ts
@@ -5,7 +5,7 @@ const momentConstructor = moment;
 
 @Pipe({ name: 'amParse' })
 export class ParsePipe implements PipeTransform {
-  transform(value: string, format: string): moment.Moment {
-    return momentConstructor(value, format);
+  transform(value: string, formats: string|string[]): moment.Moment {
+    return momentConstructor(value, formats);
   }
 }


### PR DESCRIPTION
As per issue https://github.com/urish/ngx-moment/issues/186