### PR TITLE
Date type for amLocale pipe

### DIFF
--- a/src/locale.pipe.ts
+++ b/src/locale.pipe.ts
@@ -6,7 +6,7 @@ const momentConstructor = moment;
 
 @Pipe({ name: 'amLocale' })
 export class LocalePipe implements PipeTransform {
-  transform(value: string, locale: string): moment.Moment {
+  transform(value: string | Date, locale: string): moment.Moment {
     return momentConstructor(value).locale(locale);
   }
 }


### PR DESCRIPTION
It turns out that during AOT builds of NG apps there are issues when Date type is being passed to the pipe. While Momentjs accepts Date in it's constructor